### PR TITLE
fix: Exibe nomes das squads em vez de IDs na tela de detalhes da release

### DIFF
--- a/frontend/releases-frontend/src/app/components/release-detail/release-detail.html
+++ b/frontend/releases-frontend/src/app/components/release-detail/release-detail.html
@@ -226,7 +226,7 @@
       <div class="card-body">
         <div class="squads-list">
           <div class="squad-item" *ngFor="let squadId of release.squads_participantes">
-            <span class="squad-name">{{ squadId }}</span>
+            <span class="squad-name">{{ getSquadName(squadId) }}</span>
           </div>
         </div>
       </div>

--- a/frontend/releases-frontend/src/app/components/release-detail/release-detail.ts
+++ b/frontend/releases-frontend/src/app/components/release-detail/release-detail.ts
@@ -321,6 +321,11 @@ export class ReleaseDetailComponent implements OnInit {
     return this.authService.getCurrentUser()?.role === 'admin';
   }
 
+  getSquadName(squadId: string): string {
+    const squad = this.squads.find(s => s.squad_id === squadId);
+    return squad ? squad.squad_name : squadId;
+  }
+
   clearMessages() {
     this.error = '';
     this.success = '';


### PR DESCRIPTION
✅ Correção Implementada:
- Adicionado método getSquadName() no componente release-detail
- Template atualizado para usar {{ getSquadName(squadId) }}
- Agora exibe nomes legíveis das squads em vez dos IDs técnicos
- Melhora significativa na experiência do usuário

🔧 Alterações Técnicas:
- release-detail.ts: Novo método para buscar nome da squad pelo ID
- release-detail.html: Template atualizado para exibir nomes
- Integração com lista de squads carregada da API

✨ Resultado:
- Squads agora aparecem com nomes descritivos
- Interface mais amigável para o time de qualidade
- Mantém compatibilidade com IDs existentes