### PR TITLE
feat: Ajustar filtros de status e adicionar filtro por Release

### DIFF
--- a/frontend/releases-frontend/src/app/components/releases-list/releases-list.html
+++ b/frontend/releases-frontend/src/app/components/releases-list/releases-list.html
@@ -142,14 +142,6 @@
               </svg>
               Atualizar
             </button>
-            <button class="btn btn-secondary" (click)="exportToExcel()" type="button">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                <polyline points="7,10 12,15 17,10"></polyline>
-                <line x1="12" y1="15" x2="12" y2="3"></line>
-              </svg>
-              Exportar Excel
-            </button>
           </div>
         </div>
       </section>

--- a/frontend/releases-frontend/src/app/components/releases-list/releases-list.ts
+++ b/frontend/releases-frontend/src/app/components/releases-list/releases-list.ts
@@ -202,10 +202,6 @@ export class ReleasesListComponent implements OnInit, OnDestroy {
     console.log('Atualizar release', this.selectedRelease);
   }
 
-  exportToExcel(): void {
-    console.log('Exportar para Excel', this.selectedRelease);
-  }
-
   trackByReleaseId(index: number, release: Release): string {
     return release.release_id;
   }

--- a/frontend/releases-frontend/src/app/components/releases-table/releases-table.html
+++ b/frontend/releases-frontend/src/app/components/releases-table/releases-table.html
@@ -47,22 +47,21 @@
             (change)="onFilterChange()"
           >
             <option value="">Todos os status</option>
-            <option *ngFor="let status of statusOptions" [value]="status">
-              {{ status }}
-            </option>
+            <option value="em andamento">Em Andamento</option>
+            <option value="concluído">Concluído</option>
           </select>
         </div>
         
         <div class="filter-group">
-          <label for="squadFilter">Filtrar por Squad:</label>
+          <label for="releaseFilter">Filtrar por Release:</label>
           <select 
-            id="squadFilter" 
-            [(ngModel)]="squadFilter" 
+            id="releaseFilter" 
+            [(ngModel)]="releaseFilter" 
             (change)="onFilterChange()"
           >
-            <option value="">Todas as squads</option>
-            <option *ngFor="let squad of getUniqueSquads()" [value]="squad">
-              {{ squad }}
+            <option value="">Todas as releases</option>
+            <option *ngFor="let release of getUniqueReleases()" [value]="release">
+              {{ release }}
             </option>
           </select>
         </div>
@@ -70,9 +69,6 @@
         <div class="filter-actions">
           <button class="btn btn-secondary" (click)="refreshData()">
             🔄 Atualizar
-          </button>
-          <button class="btn btn-secondary" (click)="exportToExcel()">
-            📊 Exportar
           </button>
         </div>
       </div>
@@ -99,7 +95,7 @@
       <div class="table-info">
         <p>
           Mostrando {{ filteredReleases.length }} de {{ releases.length }} releases
-          <span *ngIf="statusFilter || squadFilter"> (filtradas)</span>
+          <span *ngIf="statusFilter || releaseFilter"> (filtradas)</span>
         </p>
       </div>
 
@@ -256,13 +252,13 @@
       <div *ngIf="filteredReleases.length === 0" class="empty-state">
         <div class="empty-icon">📦</div>
         <h3>Nenhuma release encontrada</h3>
-        <p *ngIf="statusFilter || squadFilter">
+        <p *ngIf="statusFilter || releaseFilter">
           Tente ajustar os filtros ou 
-          <button class="link-btn" (click)="statusFilter = ''; squadFilter = ''; onFilterChange()">
+          <button class="link-btn" (click)="statusFilter = ''; releaseFilter = ''; onFilterChange()">
             limpar filtros
           </button>
         </p>
-        <p *ngIf="!statusFilter && !squadFilter">
+        <p *ngIf="!statusFilter && !releaseFilter">
           Não há releases {{ currentView }} disponíveis no momento.
         </p>
       </div>

--- a/frontend/releases-frontend/src/app/components/releases-table/releases-table.ts
+++ b/frontend/releases-frontend/src/app/components/releases-table/releases-table.ts
@@ -26,7 +26,7 @@ export class ReleasesTableComponent implements OnInit {
   // Filtros
   currentView: 'homolog' | 'alpha' = 'homolog';
   statusFilter: string = '';
-  squadFilter: string = '';
+  releaseFilter: string = '';
   
   // Edição inline
   editingReleaseId: string | null = null;
@@ -100,11 +100,11 @@ export class ReleasesTableComponent implements OnInit {
       // Filtro por status
       const matchesStatus = !this.statusFilter || release.status === this.statusFilter;
       
-      // Filtro por squad
-      const matchesSquad = !this.squadFilter || 
-        (release.squad && release.squad.toLowerCase().includes(this.squadFilter.toLowerCase()));
+      // Filtro por release
+      const matchesRelease = !this.releaseFilter || 
+        (release.release_name && release.release_name.toLowerCase().includes(this.releaseFilter.toLowerCase()));
       
-      return matchesView && matchesStatus && matchesSquad;
+      return matchesView && matchesStatus && matchesRelease;
     });
   }
 
@@ -229,11 +229,6 @@ export class ReleasesTableComponent implements OnInit {
     this.loadReleases();
   }
 
-  exportToExcel(): void {
-    // Implementar exportação para Excel
-    this.showMessage('Funcionalidade de exportação em desenvolvimento', 'info');
-  }
-
   showMessage(text: string, type: string): void {
     this.message = text;
     this.messageType = type;
@@ -245,12 +240,12 @@ export class ReleasesTableComponent implements OnInit {
     }, 5000);
   }
 
-  getUniqueSquads(): string[] {
-    const squads = this.releases
-      .map(r => r.squad)
-      .filter(squad => squad && squad.trim() !== '')
-      .filter((squad, index, arr) => arr.indexOf(squad) === index);
-    return squads as string[];
+  getUniqueReleases(): string[] {
+    const releases = this.releases
+      .map(r => r.release_name)
+      .filter(release => release && release.trim() !== '')
+      .filter((release, index, arr) => arr.indexOf(release) === index);
+    return releases as string[];
   }
 
   trackByReleaseId(index: number, release: Release): string {


### PR DESCRIPTION
- Limitado filtro de status apenas para 'Em Andamento' e 'Concluído'
- Substituído filtro por Squad por filtro por Release
- Removido botões de exportação dos componentes releases-list e releases-table
- Corrigido referências ao squadFilter para releaseFilter
- Testado e validado funcionamento dos filtros combinados