### PR TITLE
feat: Atualizar formulário de criação de releases

### DIFF
--- a/frontend/releases-frontend/src/app/components/admin-panel/admin-panel.html
+++ b/frontend/releases-frontend/src/app/components/admin-panel/admin-panel.html
@@ -117,31 +117,46 @@
             </div>
             
             <div class="form-group">
-              <label for="responsavel">Responsável *</label>
+              <label for="linkPlanoTestes">Link Plano de Testes</label>
               <input
                 type="text"
-                id="responsavel"
-                name="responsavel"
-                [(ngModel)]="newRelease.responsavel"
-                required
-                placeholder="Nome do responsável"
+                id="linkPlanoTestes"
+                name="linkPlanoTestes"
+                [(ngModel)]="newRelease.link_plano_testes"
+                placeholder="Ex: http://link.para.plano.testes"
               />
             </div>
             
             <div class="form-group">
-              <label for="status">Status *</label>
-              <select
-                id="status"
-                name="status"
-                [(ngModel)]="newRelease.status"
-                required
-              >
-                <option value="">Selecione o status</option>
-                <option value="em andamento">Em Andamento</option>
-                <option value="concluído">Concluído</option>
-                <option value="bloqueado">Bloqueado</option>
-                <option value="concluido com bugs">Concluído com Bugs</option>
-              </select>
+              <label for="qrcodeAlpha">QR Code Alpha</label>
+              <input
+                type="text"
+                id="qrcodeAlpha"
+                name="qrcodeAlpha"
+                [(ngModel)]="newRelease.qrcode_alpha"
+                placeholder="Ex: QR Code para ambiente Alpha"
+              />
+            </div>
+            
+            <div class="form-group">
+              <label for="qrcodeHomolog">QR Code Homolog</label>
+              <input
+                type="text"
+                id="qrcodeHomolog"
+                name="qrcodeHomolog"
+                [(ngModel)]="newRelease.qrcode_homolog"
+                placeholder="Ex: QR Code para ambiente de Homologação"
+              />
+            </div>
+            
+            <div class="form-group">
+              <label for="releaseExclusiva">Release Exclusiva</label>
+              <input
+                type="checkbox"
+                id="releaseExclusiva"
+                name="releaseExclusiva"
+                [(ngModel)]="newRelease.release_exclusiva"
+              />
             </div>
             
             <div class="form-group full-width">
@@ -204,4 +219,5 @@
     </div>
   </div>
 </div>
+
 

--- a/frontend/releases-frontend/src/app/components/admin-panel/admin-panel.ts
+++ b/frontend/releases-frontend/src/app/components/admin-panel/admin-panel.ts
@@ -26,13 +26,15 @@ export class AdminPanelComponent implements OnInit {
   selectedSquads: string[] = [];
 
   newRelease: Partial<Release> = {
-    release_name: '',
-    squad: '',
-    versao_homolog: '',
-    versao_firebase: '',
-    responsavel: '',
-    status: 'em andamento',
-    descricao: ''
+    release_name: "",
+    squad: "",
+    versao_homolog: "",
+    versao_firebase: "",
+    descricao: "",
+    link_plano_testes: "",
+    qrcode_alpha: "",
+    qrcode_homolog: "",
+    release_exclusiva: false
   };
 
   constructor(
@@ -89,13 +91,15 @@ export class AdminPanelComponent implements OnInit {
 
   resetForm(): void {
     this.newRelease = {
-      release_name: '',
-      squad: '',
-      versao_homolog: '',
-      versao_firebase: '',
-      responsavel: '',
-      status: 'em andamento',
-      descricao: ''
+      release_name: "",
+      squad: "",
+      versao_homolog: "",
+      versao_firebase: "",
+      descricao: "",
+      link_plano_testes: "",
+      qrcode_alpha: "",
+      qrcode_homolog: "",
+      release_exclusiva: false
     };
     this.selectedSquads = [];
   }
@@ -118,7 +122,7 @@ export class AdminPanelComponent implements OnInit {
 
   createRelease(): void {
     if (!this.newRelease.release_name || this.selectedSquads.length === 0 || !this.newRelease.versao_homolog || 
-        !this.newRelease.versao_firebase || !this.newRelease.responsavel || !this.newRelease.status) {
+        !this.newRelease.versao_firebase) {
       this.showMessage('Por favor, preencha todos os campos obrigatórios e selecione pelo menos uma squad.', 'error');
       return;
     }

--- a/frontend/releases-frontend/src/app/components/dashboard/dashboard.html
+++ b/frontend/releases-frontend/src/app/components/dashboard/dashboard.html
@@ -120,8 +120,8 @@
         <div class="release-card" *ngFor="let release of releases.slice(0, 6)" (click)="navigateToReleaseDetail(release.release_id!)">
           <div class="release-header">
             <h3>{{ release.release_name }}</h3>
-            <span class="status-badge" [class]="getStatusClass(release.status)">
-              {{ release.status }}
+            <span class="status-badge active">
+              Ativo
             </span>
           </div>
           

--- a/frontend/releases-frontend/src/app/components/releases-table/releases-table.html
+++ b/frontend/releases-frontend/src/app/components/releases-table/releases-table.html
@@ -107,8 +107,6 @@
               <th>Squad</th>
               <th>Versão Homolog</th>
               <th>Versão Firebase</th>
-              <th>Responsável</th>
-              <th>Status</th>
               <th>Criado em</th>
               <th *ngIf="canEdit()">Ações</th>
             </tr>
@@ -170,41 +168,9 @@
                 />
               </td>
               
-              <!-- Responsável -->
-              <td>
-                <span *ngIf="editingReleaseId !== release.release_id || editingField !== 'responsavel'">
-                  {{ release.responsavel || '-' }}
-                </span>
-                <input 
-                  *ngIf="editingReleaseId === release.release_id && editingField === 'responsavel'"
-                  type="text"
-                  [(ngModel)]="editingValue"
-                  class="edit-input"
-                  (keyup.enter)="saveEdit()"
-                  (keyup.escape)="cancelEdit()"
-                />
-              </td>
+
               
-              <!-- Status -->
-              <td>
-                <span 
-                  *ngIf="editingReleaseId !== release.release_id || editingField !== 'status'"
-                  class="status-badge"
-                  [class]="getStatusClass(release.status || '')"
-                >
-                  {{ release.status || 'Não definido' }}
-                </span>
-                <select 
-                  *ngIf="editingReleaseId === release.release_id && editingField === 'status'"
-                  [(ngModel)]="editingValue"
-                  class="edit-select"
-                  (change)="saveEdit()"
-                >
-                  <option *ngFor="let status of statusOptions" [value]="status">
-                    {{ status }}
-                  </option>
-                </select>
-              </td>
+
               
               <!-- Data de Criação -->
               <td class="date-cell">
@@ -218,8 +184,8 @@
                   <button 
                     *ngIf="editingReleaseId !== release.release_id"
                     class="btn-icon edit-btn" 
-                    (click)="startEdit(release.release_id!, 'status', release.status || '')"
-                    title="Editar Status"
+                    (click)="startEdit(release.release_id!, 'release_name', release.release_name || '')"
+                    title="Editar Release"
                   >
                     ✏️
                   </button>

--- a/frontend/releases-frontend/src/app/components/releases-table/releases-table.ts
+++ b/frontend/releases-frontend/src/app/components/releases-table/releases-table.ts
@@ -97,14 +97,11 @@ export class ReleasesTableComponent implements OnInit {
         (release.ambiente === 'homolog' || !release.ambiente) : 
         release.ambiente === 'alpha';
       
-      // Filtro por status
-      const matchesStatus = !this.statusFilter || release.status === this.statusFilter;
-      
       // Filtro por release
       const matchesRelease = !this.releaseFilter || 
         (release.release_name && release.release_name.toLowerCase().includes(this.releaseFilter.toLowerCase()));
       
-      return matchesView && matchesStatus && matchesRelease;
+      return matchesView && matchesRelease;
     });
   }
 

--- a/frontend/releases-frontend/src/app/services/api.service.ts
+++ b/frontend/releases-frontend/src/app/services/api.service.ts
@@ -15,8 +15,7 @@ export interface Release {
   squad?: string;
   versao_homolog?: string;
   versao_firebase?: string;
-  responsavel?: string;
-  status: string;
+
   descricao?: string;
   ambiente?: string;
   sla_start_time?: string;


### PR DESCRIPTION
- Remover campos 'status' e 'responsável' do formulário
- Adicionar novos campos: link_plano_testes, qrcode_alpha, qrcode_homolog, release_exclusiva
- Atualizar interface Release no api.service.ts
- Corrigir referências aos campos removidos em dashboard e releases-table
- Remover colunas dos campos removidos da tabela de releases