### PR TITLE
feat: Implementar filtragem por ambiente nas telas de teste

### DIFF
--- a/frontend/releases-frontend/src/app/app.routes.ts
+++ b/frontend/releases-frontend/src/app/app.routes.ts
@@ -11,6 +11,7 @@ import { SimplifiedReleasesListComponent } from './components/simplified-release
 import { SimplifiedReleaseDetailComponent } from './components/simplified-release-detail/simplified-release-detail';
 import { ReleaseTestStatusComponent } from './components/release-test-status/release-test-status';
 import { SquadsParticipantesComponent } from './components/squads-participantes/squads-participantes';
+import { SquadsAlphaComponent } from './components/squads-alpha/squads-participantes';
 import { ReportsComponent } from './components/reports/reports';
 
 export const routes: Routes = [
@@ -28,7 +29,7 @@ export const routes: Routes = [
   { path: 'homolog', component: SquadsParticipantesComponent }, // Redirecionado para a nova lista simplificada
  // { path: 'simplified-releases', component: SimplifiedReleasesListComponent },
   { path: 'simplified-release/:id', component: SimplifiedReleaseDetailComponent },
-  { path: 'alpha', component: ReleasesTableComponent },
+  { path: 'alpha', component: SquadsAlphaComponent },
   { path: '**', redirectTo: '/login' }
 ];
 

--- a/frontend/releases-frontend/src/app/components/squads-alpha/squads-participantes.ts
+++ b/frontend/releases-frontend/src/app/components/squads-alpha/squads-participantes.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 import { ApiService, Release, SquadParticipante } from '../../services/api.service';
 
 @Component({
-  selector: 'app-squads-participantes',
+  selector: 'app-squads-alpha',
   standalone: true,
   imports: [CommonModule, FormsModule],
   template: `
@@ -14,7 +14,7 @@ import { ApiService, Release, SquadParticipante } from '../../services/api.servi
         <button class="back-button" (click)="goBack()">
           ← Voltar
         </button>
-        <h1>Homologação</h1>
+        <h1>Testes Alpha</h1>
         <button class="refresh-button" (click)="loadReleases()" [disabled]="loading">
           🔄 Atualizar
         </button>
@@ -645,7 +645,7 @@ import { ApiService, Release, SquadParticipante } from '../../services/api.servi
     }
   `]
 })
-export class SquadsParticipantesComponent implements OnInit {
+export class SquadsAlphaComponent implements OnInit {
   releases: Release[] = [];
   filteredReleases: Release[] = [];
   loading = false;
@@ -710,10 +710,10 @@ export class SquadsParticipantesComponent implements OnInit {
 
   applyFilters() {
     this.filteredReleases = this.releases.filter(release => {
-      // Filtrar apenas releases do ambiente homolog (ou sem ambiente definido para compatibilidade)
-      const isHomologRelease = release.ambiente === 'homolog' || !release.ambiente;
+      // Filtrar apenas releases do ambiente alpha
+      const isAlphaRelease = release.ambiente === 'alpha';
       
-      if (!isHomologRelease) {
+      if (!isAlphaRelease) {
         return false;
       }
       


### PR DESCRIPTION
- Criar componente SquadsAlphaComponent para Testes Alpha
- Modificar SquadsParticipantesComponent para filtrar apenas releases do ambiente homolog
- Atualizar rotas para usar o novo componente para a rota /alpha
- Agora Testes Alpha exibe apenas releases com ambiente='alpha'
- Testes Homolog exibe apenas releases com ambiente='homolog' ou sem ambiente definido